### PR TITLE
chore: Add kubernetes manifests

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valorant-site
+  labels:
+    app: valorant-site
+spec:
+  selector:
+    matchLabels:
+      app: valorant-site
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        app: valorant-site
+        tier: frontend
+    spec:
+      containers:
+      - name: valorant-site
+        image: ghcr.io/gathering/valorant.gathering.org:main
+        ports:
+        - name: web
+          containerPort: 80
+  strategy:
+    type: Recreate

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,17 @@
+
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: valorant-site
+spec:
+  entryPoints:
+  - websecure
+  routes:
+  - kind: Rule
+    priority: 10
+    match: Host(`valorant.gathering.org`)
+    services:
+    - name: valorant-site
+      port: 80
+  tls:
+    secretName: valorant-ingress

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,7 @@
+namespace: valorant-site
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- service.yaml
+- ingress.yaml

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: valorant-site
+  labels:
+    app: valorant-site
+spec:
+  selector:
+    app: valorant-site
+    tier: frontend
+  ports:
+  - port: 80


### PR DESCRIPTION
Add basic kustomize manifests to deploy in kubernetes.

Consists of
- Deployment to run the stateless application
- Service to route traffic to the deployment.
- Ingress with Traefik

Todo:

- [x] Add DNS to k8s-ingress.gathering.systems
- [x] Create certificate on LB*
- [x] Deploy this in ArgoCD
- [x] Add ArgoCD Image updater to application in ArgoCD

* Certificates in FortiADC is done using a custom fortiadc-certbot.
