### PR TITLE
fix: Change deployment strategy to RollingUpdate and add livenessProbe

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -21,5 +21,9 @@ spec:
         ports:
         - name: web
           containerPort: 80
+        livenessProbe:
+          httpGet:
+            path: /
+            port: web
   strategy:
     type: RollingUpdate

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -22,4 +22,4 @@ spec:
         - name: web
           containerPort: 80
   strategy:
-    type: Recreate
+    type: RollingUpdate


### PR DESCRIPTION
No need for this to be `Recreate` RollingUpdate will not take down the old pod before a new one is ready.
Add livenessProbe to do a basic healthcheck on deployment